### PR TITLE
custom collumn rendering functionality

### DIFF
--- a/datatables-core/src/main/java/com/github/dandelion/datatables/core/constants/DTConstants.java
+++ b/datatables-core/src/main/java/com/github/dandelion/datatables/core/constants/DTConstants.java
@@ -92,4 +92,5 @@ public class DTConstants {
 	public static final String DT_SORT_INIT = "aaSorting";
 	public static final String DT_SORT_DIR = "asSorting";
 	public static final String DT_DATA = "mData";
+	public static final String DT_COLUMN_RENDERER = "mRender";
 }

--- a/datatables-core/src/main/java/com/github/dandelion/datatables/core/generator/MainGenerator.java
+++ b/datatables-core/src/main/java/com/github/dandelion/datatables/core/generator/MainGenerator.java
@@ -88,6 +88,10 @@ public class MainGenerator {
         			tmp.put(DTConstants.DT_DATA, column.getProperty());
         		}
         		
+        		if (StringUtils.isNotBlank(column.getRenderFunction())) {
+        			tmp.put(DTConstants.DT_COLUMN_RENDERER, new JSFunction(column.getRenderFunction()));
+        		}
+        		
         		if(column.getDefaultValue() != null){
         			tmp.put(DTConstants.DT_S_DEFAULT_CONTENT, column.getDefaultValue());
         		}
@@ -179,5 +183,21 @@ public class MainGenerator {
         logger.debug("DataTables configuration generated");
 
         return mainConf;
+    }
+    
+    /**
+     * Private class which cause escape avoiding in JSON serialization,
+     * though datatables call it as function no as string (when escaped) 
+     * @author Pavel Janecka
+     */
+    private class JSFunction {
+    	private String functionName;
+    	public JSFunction(String functionName) {
+    		this.functionName = functionName;
+    	}
+		@Override
+		public String toString() {
+			return functionName;
+		}
     }
 }

--- a/datatables-core/src/main/java/com/github/dandelion/datatables/core/model/HtmlColumn.java
+++ b/datatables-core/src/main/java/com/github/dandelion/datatables/core/model/HtmlColumn.java
@@ -54,6 +54,7 @@ public class HtmlColumn extends HtmlTag {
 	private String defaultValue;
 	private Boolean filterable;
 	private Boolean searchable;
+	private String renderFunction;
 
 	/**
 	 * <p>
@@ -278,7 +279,8 @@ public class HtmlColumn extends HtmlTag {
 				+ sortInit + ", property=" + property + ", defaultValue=" + defaultValue
 				+ ", filterable=" + filterable + ", filterType=" + filterType + ", filterCssClass="
 				+ filterCssClass + ", filterPlaceholder=" + filterPlaceholder
-				+ ", enabledDisplayTypes=" + enabledDisplayTypes + "]";
+				+ ", enabledDisplayTypes=" + enabledDisplayTypes + ", rendererFunction="
+				+ renderFunction + "]";
 	}
 
 	public Boolean getSearchable() {
@@ -287,5 +289,13 @@ public class HtmlColumn extends HtmlTag {
 
 	public void setSearchable(Boolean searchable) {
 		this.searchable = searchable;
+	}
+
+	public String getRenderFunction() {
+		return renderFunction;
+	}
+
+	public void setRenderFunction(String rendererFunction) {
+		this.renderFunction = rendererFunction;
 	}
 }

--- a/datatables-thymeleaf/src/main/java/com/github/dandelion/datatables/thymeleaf/processor/ColumnInitializerElProcessor.java
+++ b/datatables-thymeleaf/src/main/java/com/github/dandelion/datatables/thymeleaf/processor/ColumnInitializerElProcessor.java
@@ -60,6 +60,11 @@ public class ColumnInitializerElProcessor extends AbstractElementProcessor {
 			htmlColumn.setProperty(element.getAttributeValue("dt:property").trim());
 			element.removeAttribute("dt:property");
 		}
+		
+		if(element.hasAttribute("dt:renderFunction")) {
+			htmlColumn.setRenderFunction(element.getAttributeValue("dt:renderFunction").trim());
+			element.removeAttribute("dt:renderFunction");
+		}
 
 		if(element.hasAttribute("dt:default")){
 			htmlColumn.setDefaultValue(element.getAttributeValue("dt:default").trim());


### PR DESCRIPTION
added custom column renderer function functionality through `dt:renderFunction`

use as follows

```
<th dt:property="foo" dt:renderFunction="foobar" />
...
function foobar(data, type, full) {
  return "custom render output: " + data;
}
```
