### PR TITLE
Added DynamicAttributes support for TableTag and ColumnTag

### DIFF
--- a/datatables-core/src/main/java/com/github/dandelion/datatables/core/extension/feature/PaginationType.java
+++ b/datatables-core/src/main/java/com/github/dandelion/datatables/core/extension/feature/PaginationType.java
@@ -35,5 +35,10 @@ package com.github.dandelion.datatables.core.extension.feature;
  * @author Thibault Duchateau
  */
 public enum PaginationType {
-	TWO_BUTTON, FULL_NUMBERS, FOUR_BUTTON, SCROLLING, BOOTSTRAP, INPUT, LISTBOX
+	TWO_BUTTON, FULL_NUMBERS, FOUR_BUTTON, SCROLLING, BOOTSTRAP, INPUT, LISTBOX;
+
+	@Override
+	public String toString() {
+	    return this.name().toLowerCase();
+	}
 }

--- a/datatables-core/src/main/java/com/github/dandelion/datatables/core/html/HtmlColumn.java
+++ b/datatables-core/src/main/java/com/github/dandelion/datatables/core/html/HtmlColumn.java
@@ -31,6 +31,7 @@ package com.github.dandelion.datatables.core.html;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import com.github.dandelion.datatables.core.asset.DisplayType;
 import com.github.dandelion.datatables.core.extension.feature.FilterType;
@@ -96,6 +97,15 @@ public class HtmlColumn extends HtmlTagWithContent {
 		if(content != null) {
 			setContent(new StringBuilder(content));
 		}
+	}
+
+	public HtmlColumn(Boolean isHeader, String content, Map<String, String> dynamicAttributes) {
+		init();
+		setHeaderColumn(isHeader);
+		if(content != null) {
+			setContent(new StringBuilder(content));
+		}
+		this.dynamicAttributes = dynamicAttributes;
 	}
 
 	/**

--- a/datatables-core/src/main/java/com/github/dandelion/datatables/core/html/HtmlTable.java
+++ b/datatables-core/src/main/java/com/github/dandelion/datatables/core/html/HtmlTable.java
@@ -33,6 +33,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.MessageFormat;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -80,6 +81,15 @@ public class HtmlTable extends HtmlTag {
 		this.tag = "table";
 		this.randomId = ResourceHelper.getRamdomNumber();
 		this.id = id;
+	}
+
+	public HtmlTable(String id, HttpServletRequest request, String groupName, Map<String, String> dynamicAttributes) {
+		this.tag = "table";
+		this.randomId = ResourceHelper.getRamdomNumber();
+		this.id = id;
+		this.dynamicAttributes = dynamicAttributes;
+		tableConfiguration = TableConfiguration.getInstance(request, groupName);
+		tableConfiguration.setTableId(id);
 	}
 
 	/**

--- a/datatables-core/src/main/java/com/github/dandelion/datatables/core/html/HtmlTag.java
+++ b/datatables-core/src/main/java/com/github/dandelion/datatables/core/html/HtmlTag.java
@@ -29,6 +29,8 @@
  */
 package com.github.dandelion.datatables.core.html;
 
+import java.util.Map;
+
 /**
  * Abstract superclass for all HTML tags.
  * 
@@ -60,6 +62,11 @@ public abstract class HtmlTag {
 	protected StringBuilder cssStyle;
 
 	/**
+	 * Dynamic native HTML attributes.
+	 */
+	protected Map<String, String> dynamicAttributes;
+
+        /**
 	 * Render the tag in HTML code.
 	 * 
 	 * @return the HTML code corresponding to the tag.
@@ -76,6 +83,7 @@ public abstract class HtmlTag {
 		html.append('<');
 		html.append(this.tag);
 		html.append(getHtmlAttributes());
+		html.append(getDynamicHtmlAttributes());
 		html.append('>');
 		return html;
 	}
@@ -85,6 +93,19 @@ public abstract class HtmlTag {
 		html.append(writeAttribute("id", this.id));
 		html.append(writeAttribute("class", this.cssClass));
 		html.append(writeAttribute("style", this.cssStyle));
+		return html;
+	}
+
+	protected StringBuilder getDynamicHtmlAttributes() {
+
+		// If no dynamicAttributes set, return empty StringBuilder
+		if(dynamicAttributes == null) {
+			return new StringBuilder();
+		}
+		StringBuilder html = new StringBuilder();
+		for(Map.Entry<String, String> attribute : dynamicAttributes.entrySet()) {
+			html.append(writeAttribute(attribute.getKey(), attribute.getValue()));
+		}
 		return html;
 	}
 	
@@ -134,6 +155,14 @@ public abstract class HtmlTag {
 
 	public void setCssStyle(StringBuilder cssStyle) {
 		this.cssStyle = cssStyle;
+	}
+
+	public Map<String, String> getDynamicAttributes() {
+		return dynamicAttributes;
+	}
+
+	public void setDynamicAttributes(Map<String, String> dynamicAttributes) {
+		this.dynamicAttributes = dynamicAttributes;
 	}
 
 	public void addCssClass(String cssClass) {

--- a/datatables-jsp/src/main/java/com/github/dandelion/datatables/jsp/tag/AbstractColumnTag.java
+++ b/datatables-jsp/src/main/java/com/github/dandelion/datatables/jsp/tag/AbstractColumnTag.java
@@ -32,10 +32,13 @@ package com.github.dandelion.datatables.jsp.tag;
 import java.lang.reflect.InvocationTargetException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.tagext.BodyTagSupport;
+import javax.servlet.jsp.tagext.DynamicAttributes;
 
 import org.apache.commons.beanutils.NestedNullException;
 import org.apache.commons.beanutils.PropertyUtils;
@@ -60,7 +63,7 @@ import com.github.dandelion.datatables.core.util.StringUtils;
  * @author Thibault Duchateau
  * @since 0.1.0
  */
-public abstract class AbstractColumnTag extends BodyTagSupport {
+public abstract class AbstractColumnTag extends BodyTagSupport implements DynamicAttributes {
 
 	private static final long serialVersionUID = 1L;
 
@@ -89,6 +92,7 @@ public abstract class AbstractColumnTag extends BodyTagSupport {
 	protected String renderFunction;
 	protected String format;
 	protected String selector;
+	protected Map<String, String> dynamicAttributes;
 
 	/**
 	 * Add a column to the table when using DOM source.
@@ -102,7 +106,7 @@ public abstract class AbstractColumnTag extends BodyTagSupport {
 		AbstractTableTag parent = (AbstractTableTag) getParent();
 
 		// Init the column
-		HtmlColumn column = new HtmlColumn(isHeader, content);
+		HtmlColumn column = new HtmlColumn(isHeader, content, dynamicAttributes);
 		
 		// UID
 		if (StringUtils.isNotBlank(this.uid)) {
@@ -227,7 +231,7 @@ public abstract class AbstractColumnTag extends BodyTagSupport {
 		// Get the parent tag to access the HtmlTable
 		AbstractTableTag parent = (AbstractTableTag) getParent();
 
-		HtmlColumn column = new HtmlColumn(true, this.title);
+		HtmlColumn column = new HtmlColumn(true, this.title, dynamicAttributes);
 
 		// UID
 		if (StringUtils.isNotBlank(this.uid)) {
@@ -539,5 +543,39 @@ public abstract class AbstractColumnTag extends BodyTagSupport {
 
 	public void setSelector(String selector) {
 		this.selector = selector;
+	}
+
+	/**
+	 * Get the map of dynamic attributes.
+	 */
+	protected Map<String, String> getDynamicAttributes() {
+		return this.dynamicAttributes;
+        }
+
+	/** {@inheritDoc} */
+	public void setDynamicAttribute(String uri, String localName, Object value ) 
+		throws JspException {
+		if (this.dynamicAttributes == null) {
+			this.dynamicAttributes = new HashMap<String, String>();
+		}
+		if (!isValidDynamicAttribute(localName, value)) {
+			throw new IllegalArgumentException("Attribute "
+				.concat(localName).concat("=\"")
+				.concat(String.valueOf(value))
+				.concat("\" is not allowed"));
+		}
+
+		// Accept String values only, because we haven't knowledge
+		// about how to transform Object to String
+		if(value instanceof String) {
+		    dynamicAttributes.put(localName, (String) value);
+		}
+	}
+
+	/**
+	 * Whether the given name-value pair is a valid dynamic attribute.
+	 */
+	protected boolean isValidDynamicAttribute(String localName, Object value) {
+		return true;
 	}
 }

--- a/datatables-jsp/src/main/java/com/github/dandelion/datatables/jsp/tag/AbstractTableTag.java
+++ b/datatables-jsp/src/main/java/com/github/dandelion/datatables/jsp/tag/AbstractTableTag.java
@@ -30,12 +30,14 @@ package com.github.dandelion.datatables.jsp.tag;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.tagext.BodyTagSupport;
+import javax.servlet.jsp.tagext.DynamicAttributes;
 
 import org.apache.commons.beanutils.PropertyUtils;
 import org.slf4j.Logger;
@@ -62,7 +64,7 @@ import com.github.dandelion.datatables.core.util.StringUtils;
  * @author Thibault Duchateau
  * @since 0.1.0
  */
-public abstract class AbstractTableTag extends BodyTagSupport {
+public abstract class AbstractTableTag extends BodyTagSupport implements DynamicAttributes {
 
 	private static final long serialVersionUID = 4788079931487986884L;
 
@@ -96,6 +98,7 @@ public abstract class AbstractTableTag extends BodyTagSupport {
 	protected String rowIdBase;
 	protected String rowIdPrefix;
 	protected String rowIdSufix;
+	protected Map<String, String> dynamicAttributes;
 
 	// Basic features
 	protected String footer;
@@ -275,5 +278,39 @@ public abstract class AbstractTableTag extends BodyTagSupport {
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	/**
+	 * Get the map of dynamic attributes.
+	 */
+	protected Map<String, String> getDynamicAttributes() {
+		return this.dynamicAttributes;
+        }
+
+	/** {@inheritDoc} */
+	public void setDynamicAttribute(String uri, String localName, Object value ) 
+		throws JspException {
+		if (this.dynamicAttributes == null) {
+			this.dynamicAttributes = new HashMap<String, String>();
+		}
+		if (!isValidDynamicAttribute(localName, value)) {
+			throw new IllegalArgumentException("Attribute "
+				.concat(localName).concat("=\"")
+				.concat(String.valueOf(value))
+				.concat("\" is not allowed"));
+		}
+
+		// Accept String values only, because we haven't knowledge
+		// about how to transform Object to String
+		if(value instanceof String) {
+		    dynamicAttributes.put(localName, (String) value);
+		}
+	}
+
+	/**
+	 * Whether the given name-value pair is a valid dynamic attribute.
+	 */
+	protected boolean isValidDynamicAttribute(String localName, Object value) {
+		return true;
 	}
 }

--- a/datatables-jsp/src/main/java/com/github/dandelion/datatables/jsp/tag/TableTag.java
+++ b/datatables-jsp/src/main/java/com/github/dandelion/datatables/jsp/tag/TableTag.java
@@ -96,7 +96,7 @@ public class TableTag extends AbstractTableTag {
 		}
 		
 		// Init the table with its DOM id and a generated random number
-		table = new HtmlTable(id, (HttpServletRequest) pageContext.getRequest(), confGroup);
+		table = new HtmlTable(id, (HttpServletRequest) pageContext.getRequest(), confGroup, dynamicAttributes);
 		try {
 			Configuration.applyConfiguration(table.getTableConfiguration(), localConf);
 		} catch (AttributeProcessingException e) {

--- a/datatables-jsp/src/main/resources/META-INF/dandelion-datatables.tld
+++ b/datatables-jsp/src/main/resources/META-INF/dandelion-datatables.tld
@@ -377,6 +377,7 @@
             http://datatables.net/extras/colreorder/)</description>
           <name>colReorder</name>
       </attribute>
+      <dynamic-attributes>true</dynamic-attributes>
    </tag>
 
    <!-- ====================================== -->
@@ -539,6 +540,7 @@
          <name>selector</name>
          <rtexprvalue>true</rtexprvalue>
       </attribute>
+      <dynamic-attributes>true</dynamic-attributes>
    </tag>
 
    <!-- ====================================== -->


### PR DESCRIPTION
Table and Column tags allows entering dynamic attributes, which means you can enter any HTML specific attributes. Imho this is a good way to solve Issue-1 https://github.com/dandelion/issues/issues/1

Fixed PaginationType bug: Datatables "sPaginationType" value is writed in uppercase and Datatables needs in lowercase. Added toString to PaginationType to converte Enum name to lowercase
