### PR TITLE
Replace getParent() by findAncestorWithClass() method

### DIFF
--- a/datatables-jsp/src/main/java/com/github/dandelion/datatables/jsp/tag/AbstractColumnTag.java
+++ b/datatables-jsp/src/main/java/com/github/dandelion/datatables/jsp/tag/AbstractColumnTag.java
@@ -108,7 +108,7 @@ public abstract class AbstractColumnTag extends BodyTagSupport implements Dynami
 	protected void addDomColumn(Boolean isHeader, String content) throws JspException {
 
 		// Get the parent tag to access the HtmlTable
-		AbstractTableTag parent = (AbstractTableTag) getParent();
+		AbstractTableTag parent = (AbstractTableTag) findAncestorWithClass(this, AbstractTableTag.class);
 
 		// Init the column
 		HtmlColumn column = new HtmlColumn(isHeader, content, dynamicAttributes);
@@ -251,7 +251,7 @@ public abstract class AbstractColumnTag extends BodyTagSupport implements Dynami
 	protected void addAjaxColumn(Boolean isHeader, String content) throws JspException {
 
 		// Get the parent tag to access the HtmlTable
-		AbstractTableTag parent = (AbstractTableTag) getParent();
+		AbstractTableTag parent = (AbstractTableTag) findAncestorWithClass(this, AbstractTableTag.class);
 
 		HtmlColumn column = new HtmlColumn(true, this.title, dynamicAttributes);
 
@@ -367,7 +367,7 @@ public abstract class AbstractColumnTag extends BodyTagSupport implements Dynami
 	 */
 	protected String getColumnContent() throws JspException {
 
-		TableTag parent = (TableTag) getParent();
+		TableTag parent = (TableTag) findAncestorWithClass(this, TableTag.class);
 
 		if (StringUtils.isNotBlank(property) && parent.getCurrentObject() != null) {
 

--- a/datatables-jsp/src/main/java/com/github/dandelion/datatables/jsp/tag/CallbackTag.java
+++ b/datatables-jsp/src/main/java/com/github/dandelion/datatables/jsp/tag/CallbackTag.java
@@ -60,8 +60,11 @@ public class CallbackTag extends TagSupport {
 	 */
 	public int doStartTag() throws JspException {
 
-		if (!(getParent() instanceof AbstractTableTag)) {
-			throw new JspException("CallbackTag must be inside the TableTag");
+		AbstractTableTag parent = (AbstractTableTag) findAncestorWithClass(this, AbstractTableTag.class);
+
+		// There isn't an ancestor of given class
+		if (parent == null) { 
+			throw new JspException("CallbackTag must be inside the AbstractTableTag");
 		}
 
 		return SKIP_BODY;
@@ -73,7 +76,7 @@ public class CallbackTag extends TagSupport {
 	public int doEndTag() throws JspException {
 		
 		// Get parent tag
-		AbstractTableTag parent = (AbstractTableTag) getParent();
+		AbstractTableTag parent = (AbstractTableTag) findAncestorWithClass(this, AbstractTableTag.class);
 
 		// Evaluate the tag only once
 		if(parent.isFirstIteration()){

--- a/datatables-jsp/src/main/java/com/github/dandelion/datatables/jsp/tag/CaptionTag.java
+++ b/datatables-jsp/src/main/java/com/github/dandelion/datatables/jsp/tag/CaptionTag.java
@@ -47,7 +47,7 @@ public class CaptionTag extends BodyTagSupport{
 	
 	@Override
 	public int doEndTag() throws JspException {
-		TableTag parent = (TableTag)getParent();
+		TableTag parent = (TableTag) findAncestorWithClass(this, TableTag.class);
 
 		HtmlCaption caption = new HtmlCaption();
 		caption.setId(id);

--- a/datatables-jsp/src/main/java/com/github/dandelion/datatables/jsp/tag/ColumnHeadTag.java
+++ b/datatables-jsp/src/main/java/com/github/dandelion/datatables/jsp/tag/ColumnHeadTag.java
@@ -67,7 +67,7 @@ public class ColumnHeadTag extends BodyTagSupport {
 
 	public int doEndTag() throws JspException {
 
-		TableTag parent = (TableTag) getParent();
+		TableTag parent = (TableTag) findAncestorWithClass(this, TableTag.class);
 
 		if (StringUtils.isNotBlank(this.uid)) {
 			HtmlColumn column = parent.getTable().getColumnHeadByUid(this.uid);

--- a/datatables-jsp/src/main/java/com/github/dandelion/datatables/jsp/tag/ColumnTag.java
+++ b/datatables-jsp/src/main/java/com/github/dandelion/datatables/jsp/tag/ColumnTag.java
@@ -63,7 +63,7 @@ public class ColumnTag extends AbstractColumnTag {
 	 * first iteration and a {@link HtmlColumn} is added for each iteration.
 	 */
 	public int doEndTag() throws JspException {
-		TableTag parent = (TableTag) getParent();
+		TableTag parent = (TableTag) findAncestorWithClass(this, TableTag.class);
 
 		// A header column must be added at first iteration
 		if(parent.isFirstIteration()){

--- a/datatables-jsp/src/main/java/com/github/dandelion/datatables/jsp/tag/ExportTag.java
+++ b/datatables-jsp/src/main/java/com/github/dandelion/datatables/jsp/tag/ExportTag.java
@@ -71,7 +71,10 @@ public class ExportTag extends TagSupport {
 	 */
 	public int doStartTag() throws JspException {
 
-		if (!(getParent() instanceof AbstractTableTag)) {
+		AbstractTableTag parent = (AbstractTableTag) findAncestorWithClass(this, AbstractTableTag.class);	    
+
+		// There isn't an ancestor of given class
+		if (parent == null) {
 			throw new JspException("ExportTag must be inside AbstractTableTag");
 		}
 
@@ -86,7 +89,7 @@ public class ExportTag extends TagSupport {
 		HttpServletRequest request = (HttpServletRequest) pageContext.getRequest();
 		
 		// Get parent tag
-		AbstractTableTag parent = (AbstractTableTag) getParent();
+		AbstractTableTag parent = (AbstractTableTag) findAncestorWithClass(this, AbstractTableTag.class);
 
 		// Evaluate the tag only once using the parent's isFirstRow method
 		if (parent.isFirstIteration()) {

--- a/datatables-jsp/src/main/java/com/github/dandelion/datatables/jsp/tag/ExtraConfTag.java
+++ b/datatables-jsp/src/main/java/com/github/dandelion/datatables/jsp/tag/ExtraConfTag.java
@@ -59,7 +59,7 @@ public class ExtraConfTag extends TagSupport {
 	 */
 	public int doEndTag() throws JspException {
 
-		AbstractTableTag parent = (AbstractTableTag) getParent();
+		AbstractTableTag parent = (AbstractTableTag) findAncestorWithClass(this, AbstractTableTag.class);
 
 		if (parent.isFirstIteration()) {
 			parent.getTable().getTableConfiguration().addExtraConf(new ExtraConf(getLocation(this.src)));
@@ -73,7 +73,7 @@ public class ExtraConfTag extends TagSupport {
 	 * @return
 	 */
 	private String getLocation(String src){
-		AbstractTableTag parent = (AbstractTableTag) getParent();
+		AbstractTableTag parent = (AbstractTableTag) findAncestorWithClass(this, AbstractTableTag.class);
 		return RequestHelper.getBaseUrl(pageContext.getRequest(), parent.getTable()) + src;
 	}
 

--- a/datatables-jsp/src/main/java/com/github/dandelion/datatables/jsp/tag/ExtraFileTag.java
+++ b/datatables-jsp/src/main/java/com/github/dandelion/datatables/jsp/tag/ExtraFileTag.java
@@ -59,7 +59,7 @@ public class ExtraFileTag extends TagSupport {
 	 */
 	public int doEndTag() throws JspException {
 		
-		AbstractTableTag parent = (AbstractTableTag) getParent();
+		AbstractTableTag parent = (AbstractTableTag) findAncestorWithClass(this, AbstractTableTag.class);
 		
 		if(parent.isFirstIteration()){
 			parent.getTable().getTableConfiguration().addExtraFile(new ExtraFile(getRealSource(this.src), this.insert));

--- a/datatables-jsp/src/main/java/com/github/dandelion/datatables/jsp/tag/PropTag.java
+++ b/datatables-jsp/src/main/java/com/github/dandelion/datatables/jsp/tag/PropTag.java
@@ -51,7 +51,10 @@ public class PropTag extends TagSupport {
 	 */
 	public int doStartTag() throws JspException {
 
-		if (!(getParent() instanceof AbstractTableTag)) {
+		AbstractTableTag parent = (AbstractTableTag) findAncestorWithClass(this, AbstractTableTag.class);	    
+
+		// There isn't an ancestor of given class
+		if (parent == null) {
 			throw new JspException("PropTag must be inside AbstractTableTag");
 		}
 
@@ -64,7 +67,7 @@ public class PropTag extends TagSupport {
 	public int doEndTag() throws JspException {
 		
 		// Get parent tag
-		AbstractTableTag parent = (AbstractTableTag) getParent();
+		AbstractTableTag parent = (AbstractTableTag) findAncestorWithClass(this, AbstractTableTag.class);
 
 		// Evaluate the tag only once using the isFirstRow method
 		if(parent.isFirstIteration()){


### PR DESCRIPTION
Added support to use findAncestorWithClass() in spite of getParent(). Issue #138
