### PR TITLE
Fix minor bug introduced in branch DANDELION-146

### DIFF
--- a/datatables-jsp/src/main/resources/META-INF/dandelion-datatables.tld
+++ b/datatables-jsp/src/main/resources/META-INF/dandelion-datatables.tld
@@ -419,17 +419,6 @@
           <name>scrollInner</name>
           <rtexprvalue>true</rtexprvalue>
       </attribute>
-      <attribute>
-          <description>Table's width to display in scrolling mode.
-          (default : disabled)</description>
-          <name>scrollX</name>
-      </attribute>
-      <attribute>
-          <description>Use more width than it might otherwise do when 
-          x-scrolling is enabled.
-          (default : disabled)</description>
-          <name>scrollInner</name>
-      </attribute>
 
       <!-- ColReorder -->
       <attribute>


### PR DESCRIPTION
Both scrollXInner and scrollX attributes were duplicated in dandelion-datatables.tld

See https://github.com/dandelion/issues/issues/151
