### PR TITLE
Not automatically set as "unsearchable" the hidden columns

### DIFF
--- a/datatables-core/src/main/java/com/github/dandelion/datatables/core/generator/configuration/DatatablesGenerator.java
+++ b/datatables-core/src/main/java/com/github/dandelion/datatables/core/generator/configuration/DatatablesGenerator.java
@@ -176,10 +176,6 @@ public class DatatablesGenerator extends AbstractConfigurationGenerator {
 
 				// Visible
 				tmp.put(DTConstants.DT_VISIBLE, column.getColumnConfiguration().getVisible());
-				if (column.getColumnConfiguration().getVisible() != null
-						&& !column.getColumnConfiguration().getVisible()) {
-					tmp.put(DTConstants.DT_SEARCHABLE, false);
-				}
 
 				// Column's content
 				if (StringUtils.isNotBlank(column.getColumnConfiguration().getProperty())) {

--- a/datatables-core/src/test/java/com/github/dandelion/datatables/core/generator/DatatablesGeneratorTest.java
+++ b/datatables-core/src/test/java/com/github/dandelion/datatables/core/generator/DatatablesGeneratorTest.java
@@ -165,22 +165,6 @@ public class DatatablesGeneratorTest {
 	}
 
 	@Test
-	public void should_override_searchable_if_column_is_not_visible() {
-		firstColumn.getColumnConfiguration().setSearchable(true);
-		firstColumn.getColumnConfiguration().setVisible(false);
-
-		Map<String, Object> mainConf = generator.generateConfig(table);
-
-		List<Map<String, Object>> columnsProperties = (List<Map<String, Object>>)mainConf.get(DTConstants.DT_AOCOLUMNS);
-		assertThat(columnsProperties).hasSize(1);
-		Map<String, Object> firstColumnProperties = columnsProperties.get(0);
-		Map<String, Object> customProperties = new HashMap<String, Object>(defaultProperties);
-		customProperties.put(DTConstants.DT_VISIBLE, false);
-		customProperties.put(DTConstants.DT_SEARCHABLE, false);
-		assertThat(firstColumnProperties).isEqualTo(customProperties);
-	}
-
-	@Test
 	public void should_set_mData() {
 		firstColumn.getColumnConfiguration().setProperty("aProperty");
 


### PR DESCRIPTION
Modified to don't automatically set as 'unsearchables' the hidden columns to solve dandelion/issues#196.
Removed test that checks that hidden columns are 'unsearchables'.
