### PR TITLE
Added support to export via AJAX multiple tables into the same page.

### DIFF
--- a/datatables-core/src/main/java/com/github/dandelion/datatables/core/export/ExportManager.java
+++ b/datatables-core/src/main/java/com/github/dandelion/datatables/core/export/ExportManager.java
@@ -182,11 +182,11 @@ public class ExportManager {
 					StringBuilder exportFuncName = new StringBuilder("ddl_dt_launch_export_");
 					exportFuncName.append(tableId);
 					exportFuncName.append("_");
-                                        exportFuncName.append(conf.getType().name());
+					exportFuncName.append(conf.getType().name());
 					
-                                        StringBuilder exportFunc = new StringBuilder("function ");
-                                        exportFunc.append(exportFuncName.toString());
-                                        exportFunc.append("(){");
+					StringBuilder exportFunc = new StringBuilder("function ");
+					exportFunc.append(exportFuncName.toString());
+					exportFunc.append("(){");
                                         
 					// HTTP GET
 					if(conf.getMethod().equals(HttpMethod.GET)){


### PR DESCRIPTION
Added support to export via AJAX multiple tables into the same page, in order to fix dandelion/issues#197: added the table ID to the _JavaScript export function name_ created dinamically in _ExportManager.java_, as is described in the issue.

Also done some code refactor. :smiley:
